### PR TITLE
Mark PR review report header as test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
         uses: mshick/add-pr-comment@v2
         with:
           message: |
-            ## 🤖 Zentrix 审查官报告
+            ## 🤖 Zentrix 审查官报告-测试
             
             ${{ steps.hadolint.outcome != 'success' && '❌ **Dockerfile** 发现规范问题，请查看日志。' || '✅ **Dockerfile** 检查通过。' }}
             


### PR DESCRIPTION
Update the PR comment message in .github/workflows/deploy.yml by changing the header from "## 🤖 Zentrix 审查官报告" to "## 🤖 Zentrix 审查官报告-测试". This labels the generated review report as a test run to distinguish it from production reports.